### PR TITLE
line up case block's end

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ case name
     puts "Welcome back, #{name}"
   when "Admin"
     puts "You have all the power!"
-  end
+end
 ```
 ( )
 ```ruby


### PR DESCRIPTION
doing testing around quizzes on unrelated stuff, noticed small indentation inconsistency
this should fix it, with the `end` now closing the case statement